### PR TITLE
Add small data files to manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ htmlcov/
 
 # Mac OS X
 *.DS_Store
+
+# Jupyter notebook utility files
+*.ipynb_checkpoints/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,8 @@ include taxcalc/gstrecords_variables.json
 include taxcalc/growfactors.csv
 include taxcalc/pit.csv
 include taxcalc/pit_weights.csv
+include taxcalc/pitSmallData.csv
+include taxcalc/pit_weightsSD.csv
 include taxcalc/gst.csv
 include taxcalc/gst_weights.csv
 include taxcalc/cit_cross.csv

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -63,7 +63,7 @@ def income_business_profession(PRFT_GAIN_BP_OTHR_SPECLTV_BUS,
                             PRFT_GAIN_BP_SPECLTV_BUS +
                             PRFT_GAIN_BP_SPCFD_BUS +
                             PRFT_GAIN_BP_INC_115BBF), TOTAL_PROFTS_GAINS_BP)
-    
+
     return Income_BP
 
 


### PR DESCRIPTION
This PR addresses Issue #158 by including the `pit_SmallData.csv` and `pit_weightsSD.csv` files in the `MANIFEST.in` file so that they will be included when the `taxcalc` package is built.